### PR TITLE
timstamp modified

### DIFF
--- a/src/driverDUOstereo.cpp
+++ b/src/driverDUOstereo.cpp
@@ -46,7 +46,7 @@ DUOStereoDriver::~DUOStereoDriver(void)
 void DUOStereoDriver::fillDUOImages(sensor_msgs::Image& leftImage, sensor_msgs::Image& rightImage, const PDUOFrame pFrameData)
 {
 
-	leftImage.header.stamp 		= ros::Time( double(pFrameData->timeStamp) * 1.e-4);
+	leftImage.header.stamp 		= double(ros::Time::now().toSec());
 	leftImage.header.frame_id 	= _camera_frame;
 	rightImage.header.stamp 	= leftImage.header.stamp;
 	rightImage.header.frame_id 	= _camera_frame;

--- a/src/driverDUOstereo.cpp
+++ b/src/driverDUOstereo.cpp
@@ -46,7 +46,7 @@ DUOStereoDriver::~DUOStereoDriver(void)
 void DUOStereoDriver::fillDUOImages(sensor_msgs::Image& leftImage, sensor_msgs::Image& rightImage, const PDUOFrame pFrameData)
 {
 
-	leftImage.header.stamp 		= double(ros::Time::now().toSec());
+	leftImage.header.stamp 		= ros::Time::now();
 	leftImage.header.frame_id 	= _camera_frame;
 	rightImage.header.stamp 	= leftImage.header.stamp;
 	rightImage.header.frame_id 	= _camera_frame;


### PR DESCRIPTION
ros::Time( double(pFrameData->timeStamp) \* 1.e-4); was giving the time since the duo_node started, but the ros time is different. I was not able to get the pointcloud as the published pointcloud is very old. The above change worked. I was getting pointcloud. I am doubtful about the type of **leftImage.header.stamp** .
